### PR TITLE
[FE-005] オンボーディング画面の実装と改善

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -680,10 +680,10 @@ export const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onComplete }
       resizeMode="cover"
     >
       <View style={styles.dimOverlay} />
-      <View style={[styles.centerContent, { width: '100%' }]}>
+      <View style={styles.centerContent}>
         <Text style={styles.h1White}>写真一枚で</Text>
         <Text style={styles.h1White}>理想の植物を見つけよう</Text>
-        <View style={{ marginTop: 32, width: '75%' }}>
+        <View style={{ marginTop: 32, alignItems: 'center', width: '100%' }}>
           <TouchableOpacity
             style={styles.primaryCta}
             onPress={completeOnboarding}
@@ -1255,8 +1255,10 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.accent,
     borderRadius: 24,
     paddingVertical: 14,
+    paddingHorizontal: 60,
     alignItems: 'center',
     justifyContent: 'center',
+    minWidth: 200,
   },
   primaryCtaText: {
     color: COLORS.textOnAccent,
@@ -1267,8 +1269,10 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255,255,255,0.9)',
     borderRadius: 24,
     paddingVertical: 14,
+    paddingHorizontal: 60,
     alignItems: 'center',
     justifyContent: 'center',
+    minWidth: 200,
   },
   secondaryCtaText: {
     color: COLORS.textOnBase,


### PR DESCRIPTION
## 概要
オンボーディング画面の実装と各種改善を行いました。

## 主な変更内容
- スプラッシュ画面と「写真一枚で理想の植物を見つけよう」画面を分離
- 画像最適化（PNG→JPG変換で約90%サイズ削減）
- フォントサイズの統一
- 最終画面のレイアウトを中央揃えに修正
- 各種アニメーションの改善とバグ修正

## テスト項目
- [x] オンボーディング全画面の動作確認
- [x] タップでの画面遷移
- [x] スワイプでの画面遷移
- [x] 各アニメーションの動作確認
- [x] 画像の表示確認
- [x] Expo Goでの実機動作確認

## スクリーンショット
- スプラッシュ画面から次画面への遷移がスムーズに
- 最終画面のボタンが正しく中央配置

## 関連Issue
FE-005

## その他
- 画像サイズを大幅に削減（約8MB→500KB）
- Expo Go環境での安定性向上