### PR TITLE
[BE-006] 画像アップロード機能実装

### DIFF
--- a/supabase/functions/delete-image/index.ts
+++ b/supabase/functions/delete-image/index.ts
@@ -1,0 +1,74 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req: Request) => {
+  try {
+    // Handle CORS preflight
+    if (req.method === 'OPTIONS') {
+      return new Response('ok', { headers: corsHeaders })
+    }
+
+    const { file_path, bucket } = await req.json();
+
+    if (!file_path || !bucket) {
+      throw new Error('file_path and bucket are required');
+    }
+
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+    );
+
+    // ユーザー認証
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      throw new Error('Not authenticated');
+    }
+    
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user } } = await supabaseClient.auth.getUser(token);
+
+    if (!user) {
+      throw new Error('Not authenticated');
+    }
+
+    // ユーザーのファイルか確認
+    if (!file_path.startsWith(`${user.id}/`)) {
+      throw new Error('Unauthorized to delete this file');
+    }
+
+    // ファイル削除
+    const { error } = await supabaseClient.storage
+      .from(bucket)
+      .remove([file_path]);
+
+    if (error) throw error;
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'File deleted successfully',
+      }),
+      { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: {
+          code: 'DELETE_ERROR',
+          message: error.message,
+        },
+      }),
+      { 
+        status: 500,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders } 
+      }
+    );
+  }
+});

--- a/supabase/functions/upload-image/index.ts
+++ b/supabase/functions/upload-image/index.ts
@@ -1,0 +1,170 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req: Request) => {
+  try {
+    // Handle CORS preflight
+    if (req.method === 'OPTIONS') {
+      return new Response('ok', { headers: corsHeaders })
+    }
+
+    const formData = await req.formData();
+    const file = formData.get('file') as File;
+    const type = formData.get('type') as string; // 'room' | 'avatar' | 'plant'
+    const generateThumbnail = formData.get('thumbnail') === 'true';
+
+    if (!file) {
+      throw new Error('No file provided');
+    }
+
+    // ファイルサイズチェック
+    const maxSizes = {
+      room: 10 * 1024 * 1024, // 10MB
+      avatar: 5 * 1024 * 1024, // 5MB
+      plant: 5 * 1024 * 1024,  // 5MB
+    };
+
+    const limit = maxSizes[type] ?? 10 * 1024 * 1024;
+    if (file.size > limit) {
+      throw new Error(`File size exceeds limit for ${type}`);
+    }
+
+    // MIMEタイプチェック
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+    if (!allowedTypes.includes(file.type)) {
+      throw new Error('Invalid file type');
+    }
+
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+    );
+
+    // ユーザー認証
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      throw new Error('Not authenticated');
+    }
+    
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user } } = await supabaseClient.auth.getUser(token);
+
+    if (!user) {
+      throw new Error('Not authenticated');
+    }
+
+    // バケット選択
+    const bucketMap = {
+      room: 'room-images',
+      avatar: 'user-avatars',
+      plant: 'plant-images',
+    };
+    const bucket = bucketMap[type] || 'room-images';
+
+    // ファイル名生成
+    const timestamp = Date.now();
+    const fileName = `${user.id}/${type}-${timestamp}.jpg`;
+
+    // 画像をアップロード
+    const arrayBuffer = await file.arrayBuffer();
+    const { data: mainUpload, error: mainError } = await supabaseClient.storage
+      .from(bucket)
+      .upload(fileName, arrayBuffer, {
+        contentType: file.type,
+        cacheControl: '3600',
+        upsert: true,
+      });
+
+    if (mainError) throw mainError;
+
+    // サムネイル生成（簡易版：同じ画像を使用）
+    let thumbnailUrl = null;
+    if (generateThumbnail) {
+      const thumbnailName = `${user.id}/thumb-${type}-${timestamp}.jpg`;
+
+      const { error: thumbError } = await supabaseClient.storage
+        .from(bucket)
+        .upload(thumbnailName, arrayBuffer, {
+          contentType: file.type,
+          cacheControl: '3600',
+        });
+
+      if (!thumbError) {
+        if (bucket === 'plant-images') {
+          const { data: { publicUrl } } = supabaseClient.storage
+            .from(bucket)
+            .getPublicUrl(thumbnailName);
+          thumbnailUrl = publicUrl;
+        } else {
+          const { data: signed } = await supabaseClient.storage
+            .from(bucket)
+            .createSignedUrl(thumbnailName, 60 * 60); // 1時間
+          thumbnailUrl = signed?.signedUrl ?? null;
+        }
+      }
+    }
+
+    // アクセスURLを取得（公開/非公開で処理分岐）
+    let fileUrl: string | null = null;
+    if (bucket === 'plant-images') {
+      const { data: { publicUrl } } = supabaseClient.storage
+        .from(bucket)
+        .getPublicUrl(fileName);
+      fileUrl = publicUrl;
+    } else {
+      const { data: signed } = await supabaseClient.storage
+        .from(bucket)
+        .createSignedUrl(fileName, 60 * 60);
+      fileUrl = signed?.signedUrl ?? null;
+    }
+
+    // メタデータを保存
+    const { error: metaError } = await supabaseClient
+      .from('image_metadata')
+      .insert({
+        user_id: user.id,
+        url: fileUrl,
+        thumbnail_url: thumbnailUrl,
+        type,
+        size: file.size,
+        width: null, // 画像処理ライブラリなしのため省略
+        height: null,
+      });
+
+    if (metaError) {
+      console.error('Metadata save error:', metaError);
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          url: fileUrl,
+          thumbnail_url: thumbnailUrl,
+          size: file.size,
+        },
+      }),
+      { headers: { 'Content-Type': 'application/json', ...corsHeaders } }
+    );
+  } catch (error) {
+    console.error('Upload error:', error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: {
+          code: 'UPLOAD_ERROR',
+          message: error.message,
+        },
+      }),
+      { 
+        status: 500,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders } 
+      }
+    );
+  }
+});

--- a/supabase/migrations/20250830000001_image_metadata.sql
+++ b/supabase/migrations/20250830000001_image_metadata.sql
@@ -1,0 +1,86 @@
+-- BE-006: 画像アップロード機能のためのimage_metadataテーブル作成
+-- image_metadata table for storing uploaded image information
+
+CREATE TABLE IF NOT EXISTS public.image_metadata (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+  url TEXT NOT NULL,
+  thumbnail_url TEXT,
+  type TEXT CHECK (type IN ('room', 'avatar', 'plant')),
+  size INTEGER,
+  width INTEGER,
+  height INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_image_metadata_user_id ON public.image_metadata(user_id);
+CREATE INDEX IF NOT EXISTS idx_image_metadata_type ON public.image_metadata(type);
+CREATE INDEX IF NOT EXISTS idx_image_metadata_created_at ON public.image_metadata(created_at DESC);
+
+-- Enable RLS
+ALTER TABLE public.image_metadata ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policy: Users can manage their own image metadata
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='image_metadata' AND policyname='Users can manage own image metadata'
+  ) THEN
+    CREATE POLICY "Users can manage own image metadata" 
+    ON public.image_metadata 
+    FOR ALL TO authenticated 
+    USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- Additional Storage Bucket policies (if not already exists)
+-- These complement the existing storage setup
+
+-- Ensure ar-generated bucket exists
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('ar-generated', 'ar-generated', false, 10485760, ARRAY['image/jpeg', 'image/png'])
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS Policy for ar-generated bucket
+DO $$
+BEGIN
+  -- Users can upload own AR generated images
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='storage' AND tablename='objects' AND policyname='Users can upload own ar-generated images'
+  ) THEN
+    CREATE POLICY "Users can upload own ar-generated images"
+    ON storage.objects FOR INSERT
+    TO authenticated
+    WITH CHECK (
+      bucket_id = 'ar-generated' AND 
+      (storage.foldername(name))[1] = auth.uid()::text
+    );
+  END IF;
+
+  -- Users can view own AR generated images
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='storage' AND tablename='objects' AND policyname='Users can view own ar-generated images'
+  ) THEN
+    CREATE POLICY "Users can view own ar-generated images"
+    ON storage.objects FOR SELECT
+    TO authenticated
+    USING (
+      bucket_id = 'ar-generated' AND 
+      (storage.foldername(name))[1] = auth.uid()::text
+    );
+  END IF;
+
+  -- Users can delete own AR generated images
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname='storage' AND tablename='objects' AND policyname='Users can delete own ar-generated images'
+  ) THEN
+    CREATE POLICY "Users can delete own ar-generated images"
+    ON storage.objects FOR DELETE
+    TO authenticated
+    USING (
+      bucket_id = 'ar-generated' AND 
+      (storage.foldername(name))[1] = auth.uid()::text
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## 概要
チケット #15に基づいて、画像アップロード/削除機能の Edge Functions を実装しました。

## 実装内容
- ✅ `upload-image` - 画像アップロードAPI（リサイズ処理は簡易版）
- ✅ `delete-image` - 画像削除API
- ✅ `image_metadata` テーブルの作成
- ✅ ストレージバケットのRLSポリシー設定

## 技術仕様
### アップロード機能
- ファイルサイズ制限（room:10MB, avatar/plant:5MB）
- MIMEタイプチェック（JPEG/PNG/WebP）
- バケット別の公開/非公開設定
- サムネイル生成（簡易版）
- 署名付きURL生成（非公開バケット用）

### 削除機能
- ユーザー所有権チェック
- バケットからの物理削除

### ストレージ設定
- 4つのバケット管理（room-images, plant-images, user-avatars, ar-generated）
- RLSポリシーによるアクセス制御

## テスト手順
1. Supabase Edge Functions をローカルで起動
2. FormDataで画像ファイルをPOST
3. 削除APIで画像を削除
4. Storage UIで確認

## 備考
- 画像リサイズは簡易実装（同じ画像を使用）
- 本格的な画像処理は別途ライブラリ導入後に実装予定