### PR TITLE
[FE-006] 植物管理画面の改善 - モックデータ追加と水やり管理機能

### DIFF
--- a/src/screens/MyPlantsScreen.tsx
+++ b/src/screens/MyPlantsScreen.tsx
@@ -206,7 +206,7 @@ const MyPlantsScreen: React.FC = () => {
                     </View>
                     <View style={styles.actionButtons}>
                       <TouchableOpacity 
-                        style={[styles.actionButton, wateredPlants.has(plant.id) && styles.wateredButton]}
+                        style={[styles.actionButton, styles.waterButton, wateredPlants.has(plant.id) && styles.wateredButton]}
                         onPress={(e) => handleQuickWater(plant, e)}
                       >
                         {wateredPlants.has(plant.id) ? (
@@ -216,17 +216,17 @@ const MyPlantsScreen: React.FC = () => {
                           </>
                         ) : (
                           <>
-                            <Ionicons name="water" size={18} color={COLORS.primary} />
-                            <Text style={styles.actionButtonText}>水やり</Text>
+                            <Ionicons name="water" size={18} color="#FFFFFF" />
+                            <Text style={styles.waterButtonText}>水やり</Text>
                           </>
                         )}
                       </TouchableOpacity>
                       <TouchableOpacity 
-                        style={styles.actionButton}
+                        style={[styles.actionButton, styles.aiButton]}
                         onPress={(e) => handleQuickAIConsult(plant, e)}
                       >
-                        <Ionicons name="chatbubble-ellipses-outline" size={18} color={COLORS.secondary} />
-                        <Text style={styles.actionButtonText}>AI相談</Text>
+                        <Ionicons name="chatbubble-ellipses-outline" size={18} color="#FFFFFF" />
+                        <Text style={styles.aiButtonText}>AI相談</Text>
                       </TouchableOpacity>
                     </View>
                   </TouchableOpacity>
@@ -271,7 +271,7 @@ const MyPlantsScreen: React.FC = () => {
                 </View>
                 <View style={styles.actionButtons}>
                   <TouchableOpacity 
-                    style={[styles.actionButton, wateredPlants.has(plant.id) && styles.wateredButton]}
+                    style={[styles.actionButton, styles.waterButton, wateredPlants.has(plant.id) && styles.wateredButton]}
                     onPress={(e) => handleQuickWater(plant, e)}
                   >
                     {wateredPlants.has(plant.id) ? (
@@ -281,17 +281,17 @@ const MyPlantsScreen: React.FC = () => {
                       </>
                     ) : (
                       <>
-                        <Ionicons name="water" size={18} color={COLORS.primary} />
-                        <Text style={styles.actionButtonText}>水やり</Text>
+                        <Ionicons name="water" size={18} color="#FFFFFF" />
+                        <Text style={styles.waterButtonText}>水やり</Text>
                       </>
                     )}
                   </TouchableOpacity>
                   <TouchableOpacity 
-                    style={styles.actionButton}
+                    style={[styles.actionButton, styles.aiButton]}
                     onPress={(e) => handleQuickAIConsult(plant, e)}
                   >
-                    <Ionicons name="chatbubble-ellipses-outline" size={18} color={COLORS.secondary} />
-                    <Text style={styles.actionButtonText}>AI相談</Text>
+                    <Ionicons name="chatbubble-ellipses-outline" size={18} color="#FFFFFF" />
+                    <Text style={styles.aiButtonText}>AI相談</Text>
                   </TouchableOpacity>
                 </View>
               </TouchableOpacity>
@@ -389,7 +389,7 @@ const styles = StyleSheet.create({
     shadowRadius: 4,
   },
   urgentCard: {
-    borderLeftWidth: 4,
+    borderLeftWidth: 8,
     borderLeftColor: COLORS.error,
     backgroundColor: '#FFF5F5',
   },
@@ -449,22 +449,33 @@ const styles = StyleSheet.create({
     paddingHorizontal: SPACING.sm,
     paddingVertical: SPACING.xs + 4,
     borderRadius: 12,
-    backgroundColor: COLORS.surface,
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
-    borderColor: COLORS.border,
     minWidth: 75,
     gap: 4,
   },
+  waterButton: {
+    backgroundColor: '#4FC3F7',
+    borderWidth: 0,
+  },
+  aiButton: {
+    backgroundColor: COLORS.primary,
+    borderWidth: 0,
+  },
   wateredButton: {
     backgroundColor: '#E8F5E9',
+    borderWidth: 1,
     borderColor: COLORS.success,
   },
-  actionButtonText: {
+  waterButtonText: {
     fontSize: 11,
-    color: COLORS.textSecondary,
-    fontWeight: '500',
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  aiButtonText: {
+    fontSize: 11,
+    color: '#FFFFFF',
+    fontWeight: '600',
   },
   actionButtonTextDone: {
     fontSize: 11,

--- a/src/screens/MyPlantsScreen.tsx
+++ b/src/screens/MyPlantsScreen.tsx
@@ -216,7 +216,7 @@ const MyPlantsScreen: React.FC = () => {
                           </>
                         ) : (
                           <>
-                            <Ionicons name="water" size={18} color="#FFFFFF" />
+                            <Ionicons name="water" size={18} color="#4FC3F7" />
                             <Text style={styles.waterButtonText}>水やり</Text>
                           </>
                         )}
@@ -281,7 +281,7 @@ const MyPlantsScreen: React.FC = () => {
                       </>
                     ) : (
                       <>
-                        <Ionicons name="water" size={18} color="#FFFFFF" />
+                        <Ionicons name="water" size={18} color="#4FC3F7" />
                         <Text style={styles.waterButtonText}>水やり</Text>
                       </>
                     )}
@@ -455,8 +455,9 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   waterButton: {
-    backgroundColor: '#4FC3F7',
-    borderWidth: 0,
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+    borderColor: '#4FC3F7',
   },
   aiButton: {
     backgroundColor: COLORS.primary,
@@ -469,7 +470,7 @@ const styles = StyleSheet.create({
   },
   waterButtonText: {
     fontSize: 11,
-    color: '#FFFFFF',
+    color: '#4FC3F7',
     fontWeight: '600',
   },
   aiButtonText: {

--- a/src/screens/MyPlantsScreen.tsx
+++ b/src/screens/MyPlantsScreen.tsx
@@ -216,7 +216,7 @@ const MyPlantsScreen: React.FC = () => {
                           </>
                         ) : (
                           <>
-                            <Ionicons name="water" size={18} color="#4FC3F7" />
+                            <Ionicons name="water" size={18} color="rgba(79, 195, 247, 0.8)" />
                             <Text style={styles.waterButtonText}>水やり</Text>
                           </>
                         )}
@@ -281,7 +281,7 @@ const MyPlantsScreen: React.FC = () => {
                       </>
                     ) : (
                       <>
-                        <Ionicons name="water" size={18} color="#4FC3F7" />
+                        <Ionicons name="water" size={18} color="rgba(79, 195, 247, 0.8)" />
                         <Text style={styles.waterButtonText}>水やり</Text>
                       </>
                     )}
@@ -457,7 +457,7 @@ const styles = StyleSheet.create({
   waterButton: {
     backgroundColor: 'transparent',
     borderWidth: 1.5,
-    borderColor: '#4FC3F7',
+    borderColor: 'rgba(79, 195, 247, 0.8)',
   },
   aiButton: {
     backgroundColor: COLORS.primary,
@@ -470,7 +470,7 @@ const styles = StyleSheet.create({
   },
   waterButtonText: {
     fontSize: 11,
-    color: '#4FC3F7',
+    color: 'rgba(79, 195, 247, 0.8)',
     fontWeight: '600',
   },
   aiButtonText: {


### PR DESCRIPTION
## 概要
植物管理画面（MyPlantsScreen）を大幅に改善し、実用的な水やり管理機能を追加しました。

## 変更内容

### 🌱 モックデータの追加
- 5つの植物データ（モンステラ、サンスベリア、ポトス、ゴムの木、パキラ）
- 各植物に水やり間隔、健康状態、場所情報を設定

### 📊 セクション分けによる視認性向上
- **「今日の水やり」セクション**: 水やりが必要な植物を最上部に表示（赤い太めのボーダー付き）
- **「すべての植物」セクション**: その他の植物を管理

### 💧 水やり管理機能
- 各カードに**水やりボタン**を追加（水色の輪郭線スタイル、透明度80%）
- 水やり完了時にチェックマーク表示
- 水やり日の自動更新機能

### 💬 AI相談機能
- 各カードに**AI相談ボタン**を追加（緑色背景、白文字）
- 植物ごとのAI相談への導線を確保

### 🎨 デザイン改善
- ボタンを右側で縦並び配置
- 健康状態アイコンを削除してスッキリ
- カードの高さを調整（100×120px）
- 視覚的な優先度が明確

## スクリーンショット
- 水やりが必要な植物が赤いボーダーで強調表示
- 水やり/AI相談ボタンがカード右側に配置
- セクション分けで管理しやすい画面構成

## テスト手順
1. `npm start`でExpo起動
2. Plantsタブをタップ
3. 「今日の水やり」セクションにモンちゃんが表示されることを確認
4. 水やりボタンをタップしてチェックマーク表示を確認
5. AI相談ボタンをタップしてアラート表示を確認

## 関連チケット
- FE-006: ローカル状態管理

🤖 Generated with [Claude Code](https://claude.ai/code)